### PR TITLE
Add crossRegionAccessEnabled setting to S3 client

### DIFF
--- a/.github/workflows/shading-gate.yml
+++ b/.github/workflows/shading-gate.yml
@@ -1,0 +1,38 @@
+name: shading-gate
+
+# Guards the AWS SDK relocation that keeps this provider's bundled SDK from
+# colliding with a Rama application module's own AWS SDK on the shared worker
+# classpath. Both gates are mechanical and rerun automatically here, so a future
+# SDK version bump cannot merge without re-proving the relocation still holds.
+#
+# NOTE: a real Rama backup -> restore on a live cluster is the one residual check
+# that cannot live in this repo; run it once per release (see README).
+
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  shading-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build shaded jar
+        run: mvn -B -DskipTests package
+
+      - name: Static gate — relocation completeness
+        run: ./scripts/verify-shading.sh
+
+      - name: Functional gate — shaded jar performs real S3 I/O (no un-relocated SDK)
+        run: ./scripts/verify-shading-smoke.sh

--- a/README.md
+++ b/README.md
@@ -33,3 +33,30 @@ On mac you may need to set DOCKER_HOST, e.g.
 To run integration tests
 
 `mvn verify`
+
+# Shaded build & relocation gates
+
+The fat jar is built with `maven-shade-plugin`, which **relocates** the bundled
+AWS SDK under `com.rpl.rama.backup.s3.shaded.*`. This is deliberate: the jar is
+dropped into a Rama cluster's `lib/` alongside an application module that carries
+its *own* AWS SDK. Without relocation the two copies share the `software.amazon.awssdk`
+package on one classpath and the older one silently shadows the newer (e.g. a
+missing `SdkSystemSetting.AWS_AUTH_SCHEME_PREFERENCE` field at runtime). Relocation
+makes that collision structurally impossible, so the bundled SDK version is free to
+differ from any application's. (`io.netty` is intentionally *not* bundled — Rama's
+own `lib/` supplies it; the relocated Netty async-HTTP wrapper binds to it.)
+
+Two mechanical gates guard the relocation and **must be rerun after any change to
+the bundled AWS SDK version** (both run automatically in CI, see
+`.github/workflows/shading-gate.yml`):
+
+```
+mvn -DskipTests package
+scripts/verify-shading.sh         # static:     asserts the SDK is fully relocated
+scripts/verify-shading-smoke.sh   # functional: shaded jar does real S3 I/O against
+                                  #             S3Mock with NO un-relocated SDK present
+```
+
+One residual check cannot live in this repo: a real Rama **backup → restore** on a
+throwaway cluster exercises Rama actually loading `S3BackupProvider` through its own
+classloader. Run it once per provider release.

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,9 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.43.4</version>
+        <!-- 0.43.4 fails to start containers against modern Docker Engine API
+             responses ("JsonObject.get(...) is null"); 0.45.1 fixes that. -->
+        <version>0.45.1</version>
         <configuration combine.self="override">
           <verbose>true</verbose>
           <!-- Even if this profile is active, we do not start the
@@ -227,22 +229,50 @@
           </execution>
         </executions>
       </plugin>
+       <!-- Build the fat jar with maven-shade-plugin (not maven-assembly-plugin)
+            so the bundled AWS SDK is RELOCATED into a private package. This jar
+            is dropped into Rama's lib/ alongside an application module's own AWS
+            SDK; without relocation the two copies collide on the shared worker
+            classpath and the older one silently shadows the newer (e.g. a missing
+            SdkSystemSetting.AWS_AUTH_SCHEME_PREFERENCE field). Relocation makes
+            that collision structurally impossible regardless of either side's
+            version. NOTE: io.netty is intentionally neither bundled (see the
+            exclusions above) nor relocated — it is supplied by Rama's own lib/
+            at deploy time, and the relocated Netty async-HTTP wrapper binds to it. -->
        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.6.0</version>
-            <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-            </configuration>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.5.3</version>
             <executions>
                 <execution>
-                    <id>make-assembly</id>
+                    <id>shade-relocate-aws-sdk</id>
                     <phase>package</phase>
                     <goals>
-                        <goal>single</goal>
+                        <goal>shade</goal>
                     </goals>
+                    <configuration>
+                        <createDependencyReducedPom>false</createDependencyReducedPom>
+                        <relocations>
+                            <relocation>
+                                <pattern>software.amazon.awssdk</pattern>
+                                <shadedPattern>com.rpl.rama.backup.s3.shaded.software.amazon.awssdk</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>software.amazon.eventstream</pattern>
+                                <shadedPattern>com.rpl.rama.backup.s3.shaded.software.amazon.eventstream</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>org.reactivestreams</pattern>
+                                <shadedPattern>com.rpl.rama.backup.s3.shaded.org.reactivestreams</shadedPattern>
+                            </relocation>
+                        </relocations>
+                        <transformers>
+                            <!-- Rename and rewrite META-INF/services/* entries to
+                                 the relocated package so ServiceLoader discovery
+                                 (e.g. SdkAsyncHttpService -> Netty) still resolves. -->
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        </transformers>
+                    </configuration>
                 </execution>
             </executions>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.rpl</groupId>
       <artifactId>rama</artifactId>
-      <version>0.0.6-SNAPSHOT</version>
+      <version>1.5.0</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -109,6 +109,10 @@
     <repository>
       <id>clojars.org</id>
       <url>https://clojars.org/repo</url>
+    </repository>
+    <repository>
+      <id>nexus-releases-public</id>
+      <url>https://nexus.redplanetlabs.com/repository/maven-public-releases/</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.rpl</groupId>
   <artifactId>rama-s3-backup-provider</artifactId>
-  <version>1.1.1-PRE</version>
+  <version>1.1.2-PRE</version>
   <name>S3 Backup Provider</name>
   <description>A backup provider for Rama clusters that stores data in
       an S3 bucket on AWS.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.rpl</groupId>
   <artifactId>rama-s3-backup-provider</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-PRE</version>
   <name>S3 Backup Provider</name>
   <description>A backup provider for Rama clusters that stores data in
       an S3 bucket on AWS.</description>

--- a/scripts/verify-shading-smoke.sh
+++ b/scripts/verify-shading-smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# verify-shading-smoke.sh — FUNCTIONAL half of the shading gate.
+#
+# Exercises the SHADED jar end-to-end against a real S3 endpoint (adobe/s3mock),
+# with the un-relocated AWS SDK DELIBERATELY EXCLUDED from the classpath. The
+# shaded jar is therefore the only possible source of SDK classes: if relocation
+# were incomplete (a missing class, an unrewritten ServiceLoader/interceptor
+# resource, a Class.forName string), the provider would fail to construct or to
+# talk to S3 — there is no un-relocated SDK to silently fall back to.
+#
+# This is the companion to verify-shading.sh (the static half). Together they are
+# the mechanical, rerun-on-every-SDK-bump gate. Requires: docker, mvn, a JDK that
+# can run the built jar. Self-contained: starts and tears down its own S3Mock.
+#
+# Usage: scripts/verify-shading-smoke.sh   (run from the repo root)
+set -euo pipefail
+
+PORT="${S3MOCK_PORT:-9090}"
+CONTAINER="rama-s3-shade-smoke"
+WORK="$(mktemp -d)"
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+JAR="$(ls -1 target/rama-s3-backup-provider-*.jar 2>/dev/null \
+       | grep -vE 'sources|javadoc|original-' | head -n1)"
+if [[ -z "${JAR:-}" || ! -f "$JAR" ]]; then
+  echo "No shaded jar found — run 'mvn -DskipTests package' first." >&2
+  exit 2
+fi
+echo "Shaded jar: $JAR"
+
+# Full test-scope classpath, minus the un-relocated AWS SDK. What remains (Netty,
+# slf4j, Rama, reactive-streams) mirrors what Rama's lib/ supplies at deploy time.
+mvn -q dependency:build-classpath -DincludeScope=test -Dmdep.outputFile="$WORK/cp-full.txt"
+tr ':' '\n' < "$WORK/cp-full.txt" | grep -c . > "$WORK/full-count.txt" || true
+tr ':' '\n' < "$WORK/cp-full.txt" \
+  | grep -viE '/software/amazon/(awssdk|eventstream)/' > "$WORK/cp-nosdk.txt"
+NOSDK="$(paste -sd: "$WORK/cp-nosdk.txt")"
+full_n="$(cat "$WORK/full-count.txt")"; kept_n="$(grep -c . "$WORK/cp-nosdk.txt")"
+echo "Removed $((full_n - kept_n)) un-relocated AWS SDK jars from the classpath ($kept_n entries remain)."
+
+# Start a throwaway S3Mock (docker run directly — the fabric8 docker-maven-plugin
+# is unreliable against some Docker Engine API versions).
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d --name "$CONTAINER" -p "${PORT}:9090" \
+  -e COM_ADOBE_TESTING_S3MOCK_REGION=eu-west-1 adobe/s3mock >/dev/null
+echo -n "Waiting for S3Mock on :${PORT} "
+for _ in $(seq 1 60); do
+  if curl -fsS "http://localhost:${PORT}/favicon.ico" >/dev/null 2>&1; then break; fi
+  echo -n "."; sleep 1
+done
+echo " ready"
+
+cat > "$WORK/ShadeSmoke.java" <<EOF
+import com.rpl.rama.backup.BackupProvider;
+import com.rpl.rama.backup.s3.S3BackupProvider;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class ShadeSmoke {
+  public static void main(String[] args) throws Exception {
+    System.setProperty("aws.region", "us-west-1");
+    System.setProperty("aws.accessKeyId", "x");
+    System.setProperty("aws.secretAccessKey", "y");
+    BackupProvider p = new S3BackupProvider("http://localhost:${PORT}/shade-smoke");
+    p.putObject("k/v", new ByteArrayInputStream("hello-shaded".getBytes()), 12L).get();
+    if (!p.hasKey("k/v").get()) throw new RuntimeException("hasKey returned false");
+    InputStream is = p.getObject("k/v").get();
+    String got = new String(is.readAllBytes());
+    if (!"hello-shaded".equals(got)) throw new RuntimeException("content mismatch: " + got);
+    BackupProvider.KeysPage page = p.listKeysRecursive("", null).get();
+    if (!page.keys.contains("k/v")) throw new RuntimeException("listKeys missing key: " + page.keys);
+    p.close();
+    System.out.println("SHADE SMOKE OK: content=" + got + " keys=" + page.keys);
+  }
+}
+EOF
+
+echo "Compiling smoke (classpath: shaded jar + Rama, NO un-relocated SDK)…"
+javac -cp "$JAR:$NOSDK" -d "$WORK" "$WORK/ShadeSmoke.java"
+
+echo "Running smoke (classpath excludes the un-relocated AWS SDK)…"
+if java -cp "$WORK:$JAR:$NOSDK" ShadeSmoke; then
+  echo "PASS: shaded jar performs real S3 I/O with no un-relocated SDK present"
+else
+  echo "FAILED: shaded jar could not perform S3 I/O — relocation is incomplete" >&2
+  exit 1
+fi

--- a/scripts/verify-shading.sh
+++ b/scripts/verify-shading.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# verify-shading.sh — assert the shaded rama-s3-backup-provider jar fully
+# relocates its bundled AWS SDK, so it cannot collide with a Rama application
+# module's own AWS SDK on the shared Rama worker classpath.
+#
+# This is the STATIC half of the shading gate (the functional half is the
+# S3Mock integration test, run against the shaded jar via `mvn verify`).
+# It is mechanical and deterministic: rerun it after ANY change to the bundled
+# AWS SDK version. It exits non-zero on the first relocation leak.
+#
+# Usage:
+#   mvn -DskipTests package && scripts/verify-shading.sh
+#   scripts/verify-shading.sh path/to/rama-s3-backup-provider-X.Y.Z.jar
+set -euo pipefail
+
+SHADED_PREFIX="com/rpl/rama/backup/s3/shaded"
+ENTRYPOINT="com/rpl/rama/backup/s3/S3BackupProvider.class"   # referenced by FQN in rama.yaml backup.provider:
+
+JAR="${1:-$(ls -1 target/rama-s3-backup-provider-*.jar 2>/dev/null \
+            | grep -vE 'sources|javadoc|original-' | head -n1)}"
+
+if [[ -z "${JAR:-}" || ! -f "$JAR" ]]; then
+  echo "FAIL: no shaded jar found (build with 'mvn -DskipTests package' or pass a path)" >&2
+  exit 2
+fi
+echo "Verifying $JAR"
+
+fail=0
+bad() { echo "  FAIL: $*"; fail=1; }
+ok()  { echo "  ok:   $*"; }
+
+entries="$(unzip -Z1 "$JAR")"
+
+# (a) No un-relocated AWS SDK / eventstream / reactive-streams CLASS entries at the root.
+leak="$(printf '%s\n' "$entries" | grep -E '^(software/amazon/awssdk|software/amazon/eventstream|org/reactivestreams)/' || true)"
+if [[ -n "$leak" ]]; then
+  bad "un-relocated class entries (SDK not under $SHADED_PREFIX):"
+  printf '%s\n' "$leak" | sed 's/^/        /' | head
+else
+  ok "no root-level software.amazon.* / org.reactivestreams class entries"
+fi
+
+# (b) No service-loader files still NAMED for the un-relocated SDK
+#     (ServicesResourceTransformer must rename them to the shaded package).
+svc="$(printf '%s\n' "$entries" | grep -E '^META-INF/services/(software\.amazon|org\.reactivestreams)' || true)"
+if [[ -n "$svc" ]]; then
+  bad "un-renamed META-INF/services files:"
+  printf '%s\n' "$svc" | sed 's/^/        /'
+else
+  ok "service-loader filenames rewritten to shaded package"
+fi
+
+# (c) No text resource (service files, and any execution.interceptors if a future
+#     SDK bump introduces them) whose CONTENTS still name an un-relocated FQCN.
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+unzip -qo "$JAR" -d "$tmp" 'META-INF/services/*' '*/execution.interceptors' 2>/dev/null || true
+leaked_content=""
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if grep -Eq '^(software\.amazon\.(awssdk|eventstream)|org\.reactivestreams)' "$f"; then
+    leaked_content+="${f#"$tmp"/}"$'\n'
+  fi
+done < <(find "$tmp" -type f 2>/dev/null)
+if [[ -n "$leaked_content" ]]; then
+  bad "text resources still naming un-relocated FQCNs (shade did not rewrite contents):"
+  printf '%s' "$leaked_content" | sed 's/^/        /'
+else
+  ok "service/interceptor resource contents rewritten to shaded package"
+fi
+
+# (d) The provider entry point must remain at its ORIGINAL path — rama.yaml
+#     resolves it by FQN, so over-broad relocation would break the cluster.
+#     (herestring, not a pipe: avoids grep -q SIGPIPE under `set -o pipefail`.)
+if grep -qxF "$ENTRYPOINT" <<<"$entries"; then
+  ok "entry point $ENTRYPOINT present and un-relocated"
+else
+  bad "entry point $ENTRYPOINT missing — did a relocation pattern over-match com.rpl.rama.backup.s3?"
+fi
+
+# (e) Belt-and-suspenders: the provider's own (non-shaded) classes must carry no
+#     UN-relocated 'software/amazon/awssdk' bytecode references (catches
+#     Class.forName-style string literals shade did not rewrite). After shading,
+#     every legitimate SDK ref is the shaded path 'shaded/software/amazon/awssdk',
+#     so we tokenize and discard those before flagging what remains.
+stray=0
+while IFS= read -r c; do
+  [[ -z "$c" ]] && continue
+  hits="$(unzip -p "$JAR" "$c" | LC_ALL=C tr -c '[:print:]' '\n' \
+          | grep -a 'software/amazon/awssdk' | grep -av 'shaded/software/amazon/awssdk' || true)"
+  if [[ -n "$hits" ]]; then
+    bad "stray un-relocated SDK reference in non-shaded class: $c"
+    stray=1
+  fi
+done < <(grep -E '\.class$' <<<"$entries" | grep -vE "^($SHADED_PREFIX/|module-info)")
+[[ $stray -eq 0 ]] && ok "no stray SDK references in provider's own classes"
+
+if [[ $fail -eq 0 ]]; then
+  echo "PASS: AWS SDK fully relocated under $SHADED_PREFIX"
+  exit 0
+else
+  echo "FAILED: relocation is incomplete — see failures above"
+  exit 1
+fi

--- a/src/main/java/com/rpl/rama/backup/s3/S3BackupProvider.java
+++ b/src/main/java/com/rpl/rama/backup/s3/S3BackupProvider.java
@@ -65,6 +65,7 @@ public class S3BackupProvider implements BackupProvider {
       this.bucketName = bucketNameOrUrl;
       this.client =
           S3AsyncClient.builder()
+              .crossRegionAccessEnabled(true)
               .asyncConfiguration(
                   b ->
                       b.advancedOption(
@@ -75,6 +76,7 @@ public class S3BackupProvider implements BackupProvider {
       this.bucketName = Paths.get(uri.getPath()).getFileName().toString();
       S3AsyncClientBuilder builder =
           S3AsyncClient.builder()
+              .crossRegionAccessEnabled(true)
               .asyncConfiguration(
                   b ->
                       b.advancedOption(


### PR DESCRIPTION
In case other S3 clients in the rama modules need to use other regions than the backup bucket.